### PR TITLE
昨日の記事のみを取得する機能追加とGitHub Actions設定

### DIFF
--- a/note_ai_crawler.py
+++ b/note_ai_crawler.py
@@ -6,7 +6,7 @@ import os
 import random
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
@@ -71,6 +71,7 @@ class NoteAICrawler:
         max_wait=3.0,
         detail_min_wait=2.0,
         detail_max_wait=4.0,
+        yesterday_only=False,
     ):
         """
         noteからAI関連の記事をクロールするクラス
@@ -83,6 +84,7 @@ class NoteAICrawler:
             max_wait (float): 検索時の最大待機時間（秒）
             detail_min_wait (float): 詳細取得時の最小待機時間（秒）
             detail_max_wait (float): 詳細取得時の最大待機時間（秒）
+            yesterday_only (bool): 昨日の記事のみを取得するかどうか
         """
         self.base_url = "https://note.com"
         self.search_url = f"{self.base_url}/search"
@@ -93,6 +95,7 @@ class NoteAICrawler:
         self.max_wait = max_wait
         self.detail_min_wait = detail_min_wait
         self.detail_max_wait = detail_max_wait
+        self.yesterday_only = yesterday_only
         self.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
             "Accept-Language": "ja,en-US;q=0.9,en;q=0.8",
@@ -109,7 +112,12 @@ class NoteAICrawler:
 
         for page in tqdm(range(1, self.max_pages + 1), desc="ページ"):
             try:
-                params = {"q": self.search_keyword, "page": page}
+                # 新しい順に記事を取得するためのパラメータを追加
+                params = {
+                    "q": self.search_keyword, 
+                    "page": page,
+                    "sort": "new"  # 新しい順に記事を取得
+                }
 
                 response = requests.get(self.search_url, params=params, headers=self.headers)
                 response.raise_for_status()
@@ -402,6 +410,36 @@ class NoteAICrawler:
         print(f"AI関連の記事は {len(filtered_articles)}/{len(self.articles)} 件でした。")
         self.articles = filtered_articles
 
+    def filter_yesterday_articles(self):
+        """昨日の記事のみをフィルタリング"""
+        if not self.yesterday_only:
+            return
+
+        # 昨日の日付を取得
+        yesterday = (datetime.now() - timedelta(days=1)).date()
+        yesterday_str = yesterday.strftime("%Y-%m-%d")
+        
+        filtered_articles = []
+        
+        print(f"昨日（{yesterday_str}）の記事のみをフィルタリングします...")
+        
+        for article in self.articles:
+            # 投稿日を取得
+            published_date = article.get("published_date")
+            if published_date:
+                try:
+                    # 投稿日時文字列をdatetimeオブジェクトに変換し、日付部分のみを取得
+                    published_date_obj = datetime.fromisoformat(published_date.replace("Z", "+00:00")).date()
+                    
+                    # 昨日の記事のみをフィルタリング
+                    if published_date_obj == yesterday:
+                        filtered_articles.append(article)
+                except (ValueError, TypeError) as e:
+                    print(f"投稿日の解析中にエラー: {e}")
+        
+        print(f"昨日の記事は {len(filtered_articles)}/{len(self.articles)} 件でした。")
+        self.articles = filtered_articles
+
     def save_results(self):
         """結果をCSVとJSONで保存"""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -430,6 +468,9 @@ class NoteAICrawler:
         self.search_articles()
         if self.articles:
             self.get_article_details()
+            # 昨日の記事のみをフィルタリング
+            if self.yesterday_only:
+                self.filter_yesterday_articles()
             self.filter_ai_articles()
             self.save_results()
             return True
@@ -441,6 +482,7 @@ if __name__ == "__main__":
     search_keyword = "AI"  # 検索キーワード
     max_pages = 5  # 検索する最大ページ数
     output_dir = "output"  # 出力ディレクトリ
+    yesterday_only = True  # 昨日の記事のみを取得
 
     # クローラーの実行
     crawler = NoteAICrawler(
@@ -451,6 +493,7 @@ if __name__ == "__main__":
         max_wait=3.0,
         detail_min_wait=2.0,
         detail_max_wait=4.0,
+        yesterday_only=yesterday_only,
     )
 
     crawler.run()

--- a/python-app.yml
+++ b/python-app.yml
@@ -1,0 +1,35 @@
+name: Note AI Crawler
+
+on:
+  schedule:
+    # Run at 00:00 UTC every day (09:00 JST)
+    - cron: '0 0 * * *'
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        
+    - name: Run crawler
+      run: python note_ai_crawler.py
+      
+    - name: Commit and push if there are changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add output/
+        git diff --quiet && git diff --staged --quiet || git commit -m "Update AI article data [automated]"
+        git push


### PR DESCRIPTION
## 変更内容

このPull Requestは、Issue #3 で指摘された改善点に対応しています。

### 1. 昨日の記事のみ取得する機能の追加

- クローラークラスに `yesterday_only` フラグを追加し、昨日のみの記事を取得できるようにしました
- sort=new パラメータを検索クエリに追加して新しい順に記事を取得するようにしました
- 投稿日が昨日のみの記事をフィルタリングする機能を実装しました

### 2. GitHub Actionsのワークフロー完成

- GitHub Actionsのワークフローファイルを作成しました
- 毎日UTCの0時（日本時間9時）に自動実行されるように設定しています
- 変更があった場合のみコミットとプッシュを行うようにしています

## 注意点

GitHub APIの権限の関係で、ワークフローファイルはルートディレクトリに `python-app.yml` として作成されています。
このファイルを `.github/workflows/python-app.yml` に移動してください。

## 関連Issue

Closes #3