### PR TITLE
昨日の記事のみ取得する機能とGitHub Actionsの設定追加

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,63 @@
+name: Daily Note AI Articles Crawler
+
+on:
+  schedule:
+    # 毎日午前3時（JST=UTC+9）に実行
+    - cron: '0 18 * * *'
+  # 手動実行用
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Run crawler
+      run: |
+        # 昨日の記事のみを取得するように設定
+        python -c "
+import note_ai_crawler
+
+crawler = note_ai_crawler.NoteAICrawler(
+    search_keyword='AI',
+    max_pages=5,
+    output_dir='output',
+    min_wait=1.0,
+    max_wait=3.0,
+    detail_min_wait=2.0,
+    detail_max_wait=4.0,
+    only_yesterday=True,
+)
+
+crawler.run()
+"
+
+    - name: Set up Git
+      run: |
+        git config --local user.email "github-actions@github.com"
+        git config --local user.name "GitHub Actions"
+
+    - name: Commit and push changes
+      run: |
+        # 変更があるか確認
+        if [[ -n $(git status -s) ]]; then
+          git add -A
+          git commit -m "Add new AI articles $(date +'%Y-%m-%d')"
+          git push
+        else
+          echo "No changes to commit"
+        fi


### PR DESCRIPTION
## 変更内容

このPull Requestでは、Issue #3で指摘された2つの改善点を実装しました。

### 1. 昨日の記事のみ取得する機能の追加
- `NoteAICrawler`クラスに`only_yesterday`パラメータを追加
- 昨日の日付を計算する処理を追加
- 発行日が昨日の記事のみをフィルタリングする`filter_yesterday_articles()`メソッドを実装
- `run()`メソッド内でフィルタリング処理を呼び出すよう変更

### 2. GitHub Actionsのワークフロー完成
- `.github/workflows/python-app.yml`を作成
- 毎日UTC 18:00（JST 3:00）に自動実行するようスケジュール設定
- クローラーを実行して昨日の記事のみを取得するよう設定
- 変更をGitにコミットし、リポジトリにプッシュする処理を追加

これらの変更により、毎日自動的に昨日のAI関連記事が取得され、リポジトリに保存されるようになります。

Closes #3